### PR TITLE
Added detail to LORA32 DIO1 wiring on GPIO33

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following LoRa development boards have onboard LoRa support. Most have onboa
 
 _\*1_: DIO1 must be manually wired to GPIO6.  
 _\*2_: For versions 1.0, 1.1 and 1.2 DIO1 must be manually wired to GPIO5 (version 1.3 is already wired on the PCB).  
-_\*3_: DIO1 must be manually wired to GPIO33.  
+_\*3_: DIO1 (sometimes labelled D11 or lora1 on the board) must be manually wired to GPIO33.  
 _\*4_: Requires USB to Serial adapter or Pycom Expansion Board which is explained further below.  
 _\*5_: Either display (I2C) or LED can be used but not both at the same time. LED is default disabled.  
 _\*6_: Display (64x32) not supported by LMIC-node because resolution is too small.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following LoRa development boards have onboard LoRa support. Most have onboa
 
 _\*1_: DIO1 must be manually wired to GPIO6.  
 _\*2_: For versions 1.0, 1.1 and 1.2 DIO1 must be manually wired to GPIO5 (version 1.3 is already wired on the PCB).  
-_\*3_: DIO1 (sometimes labelled D11 or lora1 on the board) must be manually wired to GPIO33.  
+_\*3_: DIO1 (sometimes labeled D11 or lora1 on the board) must be manually wired to GPIO33.  
 _\*4_: Requires USB to Serial adapter or Pycom Expansion Board which is explained further below.  
 _\*5_: Either display (I2C) or LED can be used but not both at the same time. LED is default disabled.  
 _\*6_: Display (64x32) not supported by LMIC-node because resolution is too small.


### PR DESCRIPTION
Hello ( and thanks for your work), 
First Lora32 for me, 

DIO1 refers to  the HPD13A  and GPIO33 to the board pinout,  
So it tooks me some time to understand that `HPD13A->DIO1` is wired to the board pin labelled `D11` or sometimes `lora1`.

(It depends of wiring and pictures given by sellers or googled)
I think this information can be really usefull for new users of LORA32 V2