### PR TITLE
Set up channels in OTAA mode too

### DIFF
--- a/src/LMIC-node.cpp
+++ b/src/LMIC-node.cpp
@@ -396,68 +396,6 @@ void printHeader(void)
             LMIC_setSession (0x1, DEVADDR, NWKSKEY, APPSKEY);
         #endif
 
-        #if defined(CFG_eu868)
-            // Set up the channels used by the Things Network, which corresponds
-            // to the defaults of most gateways. Without this, only three base
-            // channels from the LoRaWAN specification are used, which certainly
-            // works, so it is good for debugging, but can overload those
-            // frequencies, so be sure to configure the full frequency range of
-            // your network here (unless your network autoconfigures them).
-            // Setting up channels should happen after LMIC_setSession, as that
-            // configures the minimal channel set. The LMIC doesn't let you change
-            // the three basic settings, but we show them here.
-            LMIC_setupChannel(0, 868100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(1, 868300000, DR_RANGE_MAP(DR_SF12, DR_SF7B), BAND_CENTI);      // g-band
-            LMIC_setupChannel(2, 868500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(3, 867100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(4, 867300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(5, 867500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(6, 867700000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(7, 867900000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
-            LMIC_setupChannel(8, 868800000, DR_RANGE_MAP(DR_FSK,  DR_FSK),  BAND_MILLI);      // g2-band
-            // TTN defines an additional channel at 869.525Mhz using SF9 for class B
-            // devices' ping slots. LMIC does not have an easy way to define set this
-            // frequency and support for class B is spotty and untested, so this
-            // frequency is not configured here.
-        #elif defined(CFG_us915) || defined(CFG_au915)
-            // NA-US and AU channels 0-71 are configured automatically
-            // but only one group of 8 should (a subband) should be active
-            // TTN recommends the second sub band, 1 in a zero based count.
-            // https://github.com/TheThingsNetwork/gateway-conf/blob/master/US-global_conf.json
-            LMIC_selectSubBand(1);
-        #elif defined(CFG_as923)
-            // Set up the channels used in your country. Only two are defined by default,
-            // and they cannot be changed.  Use BAND_CENTI to indicate 1% duty cycle.
-            // LMIC_setupChannel(0, 923200000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
-            // LMIC_setupChannel(1, 923400000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
-
-            // ... extra definitions for channels 2..n here
-        #elif defined(CFG_kr920)
-            // Set up the channels used in your country. Three are defined by default,
-            // and they cannot be changed. Duty cycle doesn't matter, but is conventionally
-            // BAND_MILLI.
-            // LMIC_setupChannel(0, 922100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-            // LMIC_setupChannel(1, 922300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-            // LMIC_setupChannel(2, 922500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-
-            // ... extra definitions for channels 3..n here.
-        #elif defined(CFG_in866)
-            // Set up the channels used in your country. Three are defined by default,
-            // and they cannot be changed. Duty cycle doesn't matter, but is conventionally
-            // BAND_MILLI.
-            // LMIC_setupChannel(0, 865062500, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-            // LMIC_setupChannel(1, 865402500, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-            // LMIC_setupChannel(2, 865985000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
-
-            // ... extra definitions for channels 3..n here.
-        #endif
-
-        // Disable link check validation
-        LMIC_setLinkCheckMode(0);
-
-        // TTN uses SF9 for its RX2 window.
-        LMIC.dn2Dr = DR_SF9;
-
         // Set data rate and transmit power (note: txpow seems to be ignored by the library)
         LMIC_setDrTxpow(DR_SF7, 14);    
     }
@@ -474,6 +412,68 @@ void initLmic() {
     #ifdef ABP_ACTIVATION
         setAbpParameters();
     #endif
+
+    #if defined(CFG_eu868)
+        // Set up the channels used by the Things Network, which corresponds
+        // to the defaults of most gateways. Without this, only three base
+        // channels from the LoRaWAN specification are used, which certainly
+        // works, so it is good for debugging, but can overload those
+        // frequencies, so be sure to configure the full frequency range of
+        // your network here (unless your network autoconfigures them).
+        // Setting up channels should happen after LMIC_setSession, as that
+        // configures the minimal channel set. The LMIC doesn't let you change
+        // the three basic settings, but we show them here.
+        LMIC_setupChannel(0, 868100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(1, 868300000, DR_RANGE_MAP(DR_SF12, DR_SF7B), BAND_CENTI);      // g-band
+        LMIC_setupChannel(2, 868500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(3, 867100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(4, 867300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(5, 867500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(6, 867700000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(7, 867900000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);      // g-band
+        LMIC_setupChannel(8, 868800000, DR_RANGE_MAP(DR_FSK,  DR_FSK),  BAND_MILLI);      // g2-band
+        // TTN defines an additional channel at 869.525Mhz using SF9 for class B
+        // devices' ping slots. LMIC does not have an easy way to define set this
+        // frequency and support for class B is spotty and untested, so this
+        // frequency is not configured here.
+    #elif defined(CFG_us915) || defined(CFG_au915)
+        // NA-US and AU channels 0-71 are configured automatically
+        // but only one group of 8 should (a subband) should be active
+        // TTN recommends the second sub band, 1 in a zero based count.
+        // https://github.com/TheThingsNetwork/gateway-conf/blob/master/US-global_conf.json
+        LMIC_selectSubBand(1);
+    #elif defined(CFG_as923)
+        // Set up the channels used in your country. Only two are defined by default,
+        // and they cannot be changed.  Use BAND_CENTI to indicate 1% duty cycle.
+        // LMIC_setupChannel(0, 923200000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+        // LMIC_setupChannel(1, 923400000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_CENTI);
+
+        // ... extra definitions for channels 2..n here
+    #elif defined(CFG_kr920)
+        // Set up the channels used in your country. Three are defined by default,
+        // and they cannot be changed. Duty cycle doesn't matter, but is conventionally
+        // BAND_MILLI.
+        // LMIC_setupChannel(0, 922100000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+        // LMIC_setupChannel(1, 922300000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+        // LMIC_setupChannel(2, 922500000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+
+        // ... extra definitions for channels 3..n here.
+    #elif defined(CFG_in866)
+        // Set up the channels used in your country. Three are defined by default,
+        // and they cannot be changed. Duty cycle doesn't matter, but is conventionally
+        // BAND_MILLI.
+        // LMIC_setupChannel(0, 865062500, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+        // LMIC_setupChannel(1, 865402500, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+        // LMIC_setupChannel(2, 865985000, DR_RANGE_MAP(DR_SF12, DR_SF7),  BAND_MILLI);
+
+        // ... extra definitions for channels 3..n here.
+    #endif
+
+    // Disable link check validation
+    LMIC_setLinkCheckMode(0);
+
+    // TTN uses SF9 for its RX2 window.
+    LMIC.dn2Dr = DR_SF9;
 
     // Enable or disable ADR (data rate adaptation). 
     // Should be turned off if the device is not stationary (mobile).


### PR DESCRIPTION
Region-specific channels need to be set up in OTAA mode just like they
are in ABP. If not, join requests will not go out over the correct
frequencies.