### PR TITLE
Allow setTxIndicatorsOn to be used without USE_SERIAL defined.

### DIFF
--- a/src/LMIC-node.h
+++ b/src/LMIC-node.h
@@ -224,8 +224,11 @@ enum class ActivationMode {OTAA, ABP};
             printer.println();
         }
     }
+    
+#endif  // USE_SERIAL || USE_DISPLAY
 
 
+#if defined(USE_LED) || defined(USE_DISPLAY)
     void setTxIndicatorsOn(bool on = true)
     {
         if (on)
@@ -247,8 +250,7 @@ enum class ActivationMode {OTAA, ABP};
             #endif           
         }        
     }
-    
-#endif  // USE_SERIAL || USE_DISPLAY
+#endif  // USE_LED || USE_DISPLAY
 
 
 #ifdef USE_DISPLAY 


### PR DESCRIPTION
I disabled output to the serial port and the compilation failed because setTxIndicatorsOn was undefined. That function only uses the LED or display so it does not need to be guarded by USE_SERIAL.

I put it in its own guard with USE_LED || USE_DISPLAY.