### PR TITLE
add board support for T-BEAM-AXP2101 V1.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,11 +1,11 @@
 ;-------------------------------------------------------------------------------
 ;
 ;  File:         platformio.ini
-; 
+;
 ;  Function:     Project configuration file for LMIC-node.
 ;
 ;  Copyright:    Copyright (c) 2021 Leonel Lopes Parente
-; 
+;
 ;  License:      MIT License. See accompanying LICENSE file.
 ;
 ;  Author:       Leonel Lopes Parente
@@ -14,7 +14,7 @@
 ;                - Board selector to select your board type
 ;                - Common settings used for all boards
 ;                - Board specific settings that can be altered per board.
-;                
+;
 ;                For a description of all settings see README.md
 ;
 ;-------------------------------------------------------------------------------
@@ -27,7 +27,7 @@
 ; ------------------------------------------------------------------------------
 
 [platformio]
-default_envs = 
+default_envs =
     <platformio.ini board selector guard> Comment this line and uncomment one board-id below:
 
     ; LoRa development boards with integrated LoRa support:
@@ -47,12 +47,13 @@ default_envs =
     ; ttgo_lora32_v21                   ; TTGO LoRa32 v2.1.6
     ; ttgo_t_beam                       ; TTGO T-Beam v0.5, v0.6, v0.7
     ; ttgo_t_beam_v1                    ; TTGO T-Beam v1.0, v1.1
+    ; ttgo_t_beam_v12                   ; TTGO T-Beam v1.2
 
     ; Development boards that require an external SPI LoRa module:
 
     ; Board-id                            Board name
     ;---------                            ----------
-    ; adafruit_qt_py_m0                 ; Adafruit QT Py    
+    ; adafruit_qt_py_m0                 ; Adafruit QT Py
     ; blackpill_f103c8_128k             ; Black Pill 128k
     ; blackpill_f103c8                  ; Black Pill  64k
     ; bluepill_f103c8_128k              ; Blue Pill 128k
@@ -91,7 +92,7 @@ build_flags =
     ;                                    Is for testing purposes only.
     ;                                    Do not enable this unless you explicitly know what you are doing.
     ;
-    ; -D STM32_POST_INITSERIAL_DELAY_MS=1500  ; Workaround for STM32 boards. Can be used 
+    ; -D STM32_POST_INITSERIAL_DELAY_MS=1500  ; Workaround for STM32 boards. Can be used
     ;                                           to override value (milliseconds) in BSF.
 
 lib_deps =
@@ -107,12 +108,12 @@ lib_deps =
 [esp32]
 build_flags =
     -D hal_init=LMICHAL_init           ; Workaround for naming conflict of function hal_init
-                                       ; introduced by newer versions (> 3.5.0) of 
+                                       ; introduced by newer versions (> 3.5.0) of
                                        ; PlatformIO Espressif 32 platform (ESP32 Arduino core).
                                        ; See https://github.com/lnlp/LMIC-node/issues/41 for more information.
 
 [pico]
-upload_port = E:                       ; Shortcut for Raspberry Pi Pico. 
+upload_port = E:                       ; Shortcut for Raspberry Pi Pico.
                                        ; Operating system and hardware dependent.
                                        ; Placed here so it can be easily changed.
                                        ; See section [env:pico] below for more information.
@@ -148,7 +149,7 @@ build_flags =
     -D DISABLE_BEACONS
 
     ; -D LMIC_DEBUG_LEVEL=1            ; 0, 1 or 2
-    
+
     ; -D CFG_sx1272_radio=1            ; Use for SX1272 radio
     -D CFG_sx1276_radio=1              ; Use for SX1276 radio
     -D USE_ORIGINAL_AES                ; Faster but larger, see docs
@@ -156,9 +157,9 @@ build_flags =
     ; -D LMIC_ENABLE_DeviceTimeReq=1   ; Network time support
 
     ; --- Regional settings -----
-    ; Enable only one of the following regions:    
+    ; Enable only one of the following regions:
     ; -D CFG_as923=1
-    ; -D CFG_as923jp=1   
+    ; -D CFG_as923jp=1
     ; -D CFG_au915=1
     ; -D CFG_cn490=1                   ; Not yet supported
     ; -D CFG_cn783=1                   ; Not yet supported
@@ -173,7 +174,7 @@ build_flags =
 ; |  IBM LMIC framework library specific settings  |
 ; --------------------------------------------------
 
-[classic_lmic]    
+[classic_lmic]
 ; IMPORTANT:
 ; This library was recently DEPRECATED and is no longer maintained.
 ; It is not fully LoRaWAN compliant (e.g. in handling of MAC commands)
@@ -183,7 +184,7 @@ build_flags =
 ; They must be configured in file: config.h in the following location:
 ; .pio/libdeps/<board-id>/IBM LMIC framework/src/lmic
 ;
-; When making changes to config.h: 
+; When making changes to config.h:
 ; CONFIG.H MUST BE CHANGED FOR EACH BOARD SEPARATELY!
 ; (By default libraries are installed per project per build config/board.)
 
@@ -194,7 +195,7 @@ build_flags =
     ; DEFAULT VALUES defined in config.h:
     ; CFG_sx1276_radio 1
     ; CFG_eu868 1
-    ; LMIC_DEBUG_LEVEL 0 
+    ; LMIC_DEBUG_LEVEL 0
 
     ; Ping and beacons not supported for class A, disable to save memory.
     -D DISABLE_PING
@@ -216,17 +217,17 @@ build_flags =
 platform = atmelsam
 board = adafruit_feather_m0
 framework = arduino
-monitor_speed = ${common.monitor_speed}      
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_adafruit_feather_m0_lora.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -239,20 +240,20 @@ platform = ststm32
 board = disco_l072cz_lrwan1
 framework = arduino
 upload_protocol = stlink         ; If this fails then try mbed
-; upload_protocol = jlink        ; Requires onboard programmer firmware upgrade 
+; upload_protocol = jlink        ; Requires onboard programmer firmware upgrade
 ; upload_protocol = mbed         ; If selected, also set the correct upload_port
 ; upload_port = E:               ; Used for mbed, value is hardware and OS dependent
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_disco_l072cz_lrwan1.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -267,15 +268,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_heltec_wifi_lora_32_v2.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     -D USE_DISPLAY
@@ -290,15 +291,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_heltec_wifi_lora_32.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     -D USE_DISPLAY
@@ -313,15 +314,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_heltec_wireless_stick_lite.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -337,15 +338,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_heltec_wireless_stick.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; NOT SUPPORTED
@@ -363,15 +364,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_lopy4.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     ; -D USE_LED                 ; CURRENTLY NOT SUPPORTED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -386,9 +387,9 @@ build_flags =
 platform = atmelavr
 board = lora32u4II
 framework = arduino
-monitor_speed = ${common.monitor_speed}  
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}  
+    ${common.lib_deps}
     ${classic_lmic.lib_deps}     ; [Deprecated] IBM LMIC Framework
 build_flags =
     ${common.build_flags}
@@ -410,15 +411,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_ttgo_lora32_v1.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     ; -D USE_LED                 ; NO ONBOARD USER LED
     -D USE_DISPLAY
@@ -436,15 +437,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_ttgo_lora32_v2.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     ; -D USE_LED                 ; Cannot be used together with USE_DISPLAY
     -D USE_DISPLAY               ; Cannot be used together with USE_LED
@@ -459,18 +460,18 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_ttgo_lora32_v21.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
-    -D USE_DISPLAY    
+    -D USE_DISPLAY
 
 
 [env:ttgo_t_beam]
@@ -482,15 +483,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_ttgo_t_beam.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -506,20 +507,43 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
-    ${mcci_lmic.lib_deps} 
+    ${common.lib_deps}
+    ${mcci_lmic.lib_deps}
     lewisxhe/AXP202X_Library     ; Power management chip library
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_ttgo_t_beam_v1.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     ; -D USE_LED                 ; NO ONBOARD USER LED
-    ; -D USE_DISPLAY             ; Requires external I2C OLED display   
+    ; -D USE_DISPLAY             ; Requires external I2C OLED display
 
+[env:ttgo_t_beam_v12]
+; TTGO T-Beam  V1.2  (ESP32).
+; No onboard user LED.
+; Requires additional library and setup for AXP192 power management chip.
+platform = espressif32
+board = ttgo-t-beam
+framework = arduino
+upload_speed = 921600
+monitor_speed = ${common.monitor_speed}
+lib_deps =
+    ${common.lib_deps}
+    ${mcci_lmic.lib_deps}
+    lewisxhe/XPowersLib         ; Power management chip library
+build_flags =
+    ${common.build_flags}
+    ${esp32.build_flags}
+    ${mcci_lmic.build_flags}
+    -D BSFILE=\"boards/bsf_ttgo_t_beam_v12.h\"
+    -D MONITOR_SPEED=${common.monitor_speed}
+    -D LMIC_PRINTF_TO=Serial
+    -D USE_SERIAL
+    ; -D USE_LED                 ; NO ONBOARD USER LED
+    -D USE_DISPLAY               ; Requires external I2C OLED display
 
 ; ------------------------------------------------------------------------------
 ; |  Development boards that require an external SPI LoRa module               |
@@ -536,17 +560,17 @@ build_flags =
 platform = atmelsam
 board = adafruit_qt_py_m0
 framework = arduino
-monitor_speed = ${common.monitor_speed}      
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_adafruit_qt_py_m0.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     ; -D USE_LED                 ; CURRENTLY NOT SUPPORTED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -562,20 +586,20 @@ framework = arduino
 ; upload_protocol = serial
 upload_protocol = stlink
 ; upload_protocol = jlink
-monitor_speed = ${common.monitor_speed}    
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_blackpill_f103c8.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
-    ; -D USE_DISPLAY             ; Requires external I2C OLED display      
+    ; -D USE_DISPLAY             ; Requires external I2C OLED display
 
 
 [env:blackpill_f103c8]
@@ -588,17 +612,17 @@ framework = arduino
 ; upload_protocol = serial
 upload_protocol = stlink
 ; upload_protocol = jlink
-monitor_speed = ${common.monitor_speed}    
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_blackpill_f103c8.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -614,20 +638,20 @@ framework = arduino
 ; upload_protocol = serial
 upload_protocol = stlink
 ; upload_protocol = jlink
-monitor_speed = ${common.monitor_speed}    
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_bluepill_f103c8.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
-    ; -D USE_DISPLAY             ; Requires external I2C OLED display    
+    ; -D USE_DISPLAY             ; Requires external I2C OLED display
 
 
 [env:bluepill_f103c8]
@@ -640,17 +664,17 @@ framework = arduino
 ; upload_protocol = serial
 upload_protocol = stlink
 ; upload_protocol = jlink
-monitor_speed = ${common.monitor_speed}    
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_bluepill_f103c8.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -665,15 +689,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_lolin_d32_pro.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -688,15 +712,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_lolin_d32.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -711,15 +735,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_lolin32.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -734,15 +758,15 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
     ${esp32.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_nodemcu_32s.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
@@ -759,15 +783,16 @@ framework = arduino
 upload_speed = 921600
 monitor_speed = 74880            ; 74880 so we can read ESP8266 boot messages
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
+    WiFiManager
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_nodemcuv2.h\"
     -D MONITOR_SPEED=${env:nodemcuv2.monitor_speed}
     -D _GNU_SOURCE
-    -D LMIC_PRINTF_TO=Serial    
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; NOT SUPPORTED
@@ -782,7 +807,7 @@ build_flags =
 ; Device must be in BOOTSEL mode to upload firmware.
 ; (To put in BOOTSEL mode: press BOOTSEL button, power on or reset board, release BOOTSEL button.)
 ; For Windows specify: upload_protocol = picotool (appears not needed for Mac and Linux).
-; upload_port is operating system and hardware dependent. 
+; upload_port is operating system and hardware dependent.
 ; For convenience, to set upload_port: set upload_port in [pico] section (on top).
 ; Examples:
 ;   Windows: upload_port = E:
@@ -798,11 +823,11 @@ upload_protocol = picotool
 upload_port = ${pico.upload_port}      ; Operating system and hardware dependent
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_pico.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
     -D _GNU_SOURCE
@@ -823,7 +848,7 @@ board = pro8MHzatmega328
 framework = arduino
 monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}  
+    ${common.lib_deps}
     ${classic_lmic.lib_deps}     ; [Deprecated] IBM LMIC Framework
 build_flags =
     ${common.build_flags}
@@ -841,22 +866,22 @@ build_flags =
 platform = atmelsam
 board = zeroUSB
 framework = arduino
-monitor_speed = ${common.monitor_speed}      
+monitor_speed = ${common.monitor_speed}
 lib_deps =
-    ${common.lib_deps}    
+    ${common.lib_deps}
     ${mcci_lmic.lib_deps}
 build_flags =
     ${common.build_flags}
-    ${mcci_lmic.build_flags} 
+    ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_samd21_m0_mini.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=SerialUSB    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=SerialUSB
     -D USE_SERIAL
     ; -D USE_LED                 ; NOT SUPPORTED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
 
- 
+
 [env:teensylc]
 ; Teensy LC (NXP MKL26Z64VFT4).
 ; No display.
@@ -872,11 +897,11 @@ build_flags =
     ${mcci_lmic.build_flags}
     -D BSFILE=\"boards/bsf_teensylc.h\"
     -D MONITOR_SPEED=${common.monitor_speed}
-    -D _GNU_SOURCE    
-    -D LMIC_PRINTF_TO=Serial    
+    -D _GNU_SOURCE
+    -D LMIC_PRINTF_TO=Serial
     -D USE_SERIAL
     -D USE_LED
     ; -D USE_DISPLAY             ; Requires external I2C OLED display
 
 
-; end of file   
+; end of file

--- a/src/boards/bsf_ttgo_t_beam_v12.h
+++ b/src/boards/bsf_ttgo_t_beam_v12.h
@@ -1,0 +1,369 @@
+/*******************************************************************************
+ * 
+ *  File:         bsf_ttgo_t_beam_v12.h
+ * 
+ *  Description:  Board Support File for TTGO V1.2 .
+ * 
+ *  Copyright:    Copyright (c) 2021 Leonel Lopes Parente
+ * 
+ *  License:      MIT License. See accompanying LICENSE file.
+ * 
+ *  Author:       Leonel Lopes Parente, Goetz van Rissenbeck
+ * 
+ *  Description:  This board has onboard USB (provided by onboard USB to serial).
+ *                It supports automatic firmware upload and serial over USB. 
+ *                External display is connected.
+ *                No onboard user programmable LED..
+ * 
+ *                This board uses an AXP2101 power management chip to power
+ *                onboard components and the +3.3V output pin.
+ *                The AXP2101 must be correctly configured for things to work
+ *                (see boardInit() below).
+ * 
+ * 
+ *                CONNECTIONS AND PIN DEFINITIONS:
+ *                
+ *                Indentifiers between parentheses are defined in the board's 
+ *                Board Support Package (BSP) which is part of the Arduino core. 
+ * 
+ *                Leds                  GPIO 
+ *                ----                  ----
+ *                LED                   -          No onboard user LED
+ * 
+ *                I2C [display]         GPIO
+ *                ----                  ----
+ *                SDA     <――――――――――>  21  (SDA)
+ *                SCL     <――――――――――>  22  (SCL)
+ *                RST                    -
+ *
+ *                SPI/LoRa              GPIO
+ *                ---                   ----
+ *                MOSI    <――――――――――>  27  (MOSI) (LORA_MOSI)
+ *                MISO    <――――――――――>  19  (MISO) (LORA_MISO)
+ *                SCK     <――――――――――>   5  (SCK)  (LORA_SCK)
+ *                NSS     <――――――――――>  18  (SS)   (LORA_CS)
+ *                RST     <――――――――――>  23         (LORA_RST)
+ *                DIO0    <――――――――――>  26         (LORA_IO0)
+ *                DIO1    <――――――――――>  33         (LORA_IO1)
+ *                DIO2    <――――――――――>  32         (LORA_IO2)
+ * 
+ *                GPS                   GPIO
+ *                ---                   ----
+ *                RX      <――――――――――>  34   
+ *                TX      <――――――――――>  12  
+ *                PPS     <――――――――――>  37
+ * 
+ *                Power Management      GPIO
+ *                -----                 ----
+ *                PMU     <――――――――――>  35
+ *  
+ *                Button switches       GPIO 
+ *                ------                ----
+ *                USR_SW  <――――――――――>  39  (KEY_BUILTIN)
+ * 
+ *  Docs:         https://docs.platformio.org/en/latest/boards/espressif32/ttgo-t-beam.html
+ *
+ *  Identifiers:  LMIC-node
+ *                    board:         ttgo_tbeam_v1
+ *                PlatformIO
+ *                    board:         ttgo-t-beam
+ *                    platform:      espressif32
+ *                Arduino
+ *                    board:         ARDUINO_T_Beam
+ *                    architecture:  ARDUINO_ARCH_ESP32
+ * 
+ ******************************************************************************/
+
+#pragma once
+
+#ifndef BSF_TTGO_T_BEAM_V1_2_H_
+#define BSF_TTGO_T_BEAM_V1_2_H_
+
+// Defined using AXP2102
+#define XPOWERS_CHIP_AXP2101
+#include "XPowersAXP2101.tpp"
+#include "XPowersLibInterface.hpp"
+
+#include "LMIC-node.h"
+
+#define DEVICEID_DEFAULT "ttgo-tbeam-v1.2"  // Default deviceid value 
+
+// Wait for Serial
+// Can be useful for boards with MCU with integrated USB support.
+// #define WAITFOR_SERIAL_SECONDS_DEFAULT 10   // -1 waits indefinitely  
+
+// LMIC Clock Error
+// This is only needed for slower 8-bit MCUs (e.g. 8MHz ATmega328 and ATmega32u4).
+// Value is defined in parts per million (of MAX_CLOCK_ERROR).
+// #ifndef LMIC_CLOCK_ERROR_PPM
+//     #define LMIC_CLOCK_ERROR_PPM 0
+// #endif   
+
+// Pin mappings for LoRa tranceiver
+const lmic_pinmap lmic_pins = {
+    .nss = 18,
+    .rxtx = LMIC_UNUSED_PIN,
+    .rst = 23,
+    .dio = { /*dio0*/ 26, /*dio1*/ 33, /*dio2*/ 32 }
+#ifdef MCCI_LMIC
+    ,
+    .rxtx_rx_active = 0,
+    .rssi_cal = 10,
+    .spi_freq = 8000000     /* 8 MHz */
+#endif    
+};
+
+XPowersLibInterface *PMU = NULL;
+bool  pmu_flag = 0;
+
+
+#ifdef USE_SERIAL
+    HardwareSerial& serial = Serial;
+#endif                                        
+
+#ifdef USE_LED
+    // #error Invalid option: USE_LED. This board has no onboard user LED.
+    // EasyLed led(<external LED GPIO>, EasyLed::ActiveLevel::Low);
+#endif
+
+#ifdef USE_DISPLAY
+    // Create U8x8 instance for SSD1306 OLED display (no reset) using hardware I2C.
+    U8X8_SSD1306_128X64_NONAME_HW_I2C display(/*rst*/ U8X8_PIN_NONE, /*scl*/ SCL, /*sda*/ SDA);
+#endif
+
+
+bool initPMU() {
+    if (!PMU) {
+        PMU = new XPowersAXP2101(  Wire );
+        if (!PMU->init()) {
+            Serial.println("Warning: Failed to find AXP2101 power management");
+            delete PMU;
+            PMU = NULL;
+        } else {
+            Serial.println("AXP2101 PMU init succeeded, using AXP2101 PMU");
+        }
+    }
+
+    if (!PMU) {
+        return false;
+    }
+
+    PMU->setChargingLedMode(XPOWERS_CHG_LED_BLINK_1HZ);
+
+    // pinMode(CONFIG_PMU_IRQ, INPUT_PULLUP);
+    // attachInterrupt(CONFIG_PMU_IRQ, pmu_flag, FALLING);
+ if (PMU->getChipModel() == XPOWERS_AXP2101) {
+
+#if defined(CONFIG_IDF_TARGET_ESP32)
+        //Unuse power channel   
+        PMU->disablePowerOutput(XPOWERS_DCDC2);
+        PMU->disablePowerOutput(XPOWERS_DCDC3);
+        PMU->disablePowerOutput(XPOWERS_DCDC4);
+        PMU->disablePowerOutput(XPOWERS_DCDC5);
+        PMU->disablePowerOutput(XPOWERS_ALDO1);
+        PMU->disablePowerOutput(XPOWERS_ALDO4);
+        PMU->disablePowerOutput(XPOWERS_BLDO1);
+        PMU->disablePowerOutput(XPOWERS_BLDO2);
+        PMU->disablePowerOutput(XPOWERS_DLDO1);
+        PMU->disablePowerOutput(XPOWERS_DLDO2);
+
+        // GNSS RTC PowerVDD 3300mV
+        PMU->setPowerChannelVoltage(XPOWERS_VBACKUP, 3300);
+        PMU->enablePowerOutput(XPOWERS_VBACKUP);
+
+        //ESP32 VDD 3300mV
+        // ! No need to set, automatically open , Don't close it
+        // PMU->setPowerChannelVoltage(XPOWERS_DCDC1, 3300);
+        // PMU->setProtectedChannel(XPOWERS_DCDC1);
+        PMU->setProtectedChannel(XPOWERS_DCDC1);
+
+        // LoRa VDD 3300mV
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO2);
+
+        //GNSS VDD 3300mV
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO3);
+
+#endif /*CONFIG_IDF_TARGET_ESP32*/
+
+
+#if defined(LILYGO_TBeamS3_SUPREME_V3_0)
+
+        //t-beam m.2 inface
+        //gps
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO4, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO4);
+
+        // lora
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO3, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO3);
+
+        // In order to avoid bus occupation, during initialization, the SD card and QMC sensor are powered off and restarted
+        if (ESP_SLEEP_WAKEUP_UNDEFINED == esp_sleep_get_wakeup_cause()) {
+            Serial.println("Power off and restart ALDO BLDO..");
+            PMU->disablePowerOutput(XPOWERS_ALDO1);
+            PMU->disablePowerOutput(XPOWERS_ALDO2);
+            PMU->disablePowerOutput(XPOWERS_BLDO1);
+            delay(250);
+        }
+
+        // Sensor
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO1, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO1);
+
+        PMU->setPowerChannelVoltage(XPOWERS_ALDO2, 3300);
+        PMU->enablePowerOutput(XPOWERS_ALDO2);
+
+        //Sdcard
+
+        PMU->setPowerChannelVoltage(XPOWERS_BLDO1, 3300);
+        PMU->enablePowerOutput(XPOWERS_BLDO1);
+
+        PMU->setPowerChannelVoltage(XPOWERS_BLDO2, 3300);
+        PMU->enablePowerOutput(XPOWERS_BLDO2);
+
+        //face m.2
+        PMU->setPowerChannelVoltage(XPOWERS_DCDC3, 3300);
+        PMU->enablePowerOutput(XPOWERS_DCDC3);
+
+        PMU->setPowerChannelVoltage(XPOWERS_DCDC4, XPOWERS_AXP2101_DCDC4_VOL2_MAX);
+        PMU->enablePowerOutput(XPOWERS_DCDC4);
+
+        PMU->setPowerChannelVoltage(XPOWERS_DCDC5, 3300);
+        PMU->enablePowerOutput(XPOWERS_DCDC5);
+
+
+        //not use channel
+        PMU->disablePowerOutput(XPOWERS_DCDC2);
+        // PMU->disablePowerOutput(XPOWERS_DCDC4);
+        // PMU->disablePowerOutput(XPOWERS_DCDC5);
+        PMU->disablePowerOutput(XPOWERS_DLDO1);
+        PMU->disablePowerOutput(XPOWERS_DLDO2);
+        PMU->disablePowerOutput(XPOWERS_VBACKUP);
+
+        // Set constant current charge current limit
+        PMU->setChargerConstantCurr(XPOWERS_AXP2101_CHG_CUR_500MA);
+
+        // Set charge cut-off voltage
+        PMU->setChargeTargetVoltage(XPOWERS_AXP2101_CHG_VOL_4V2);
+
+        // Disable all interrupts
+        PMU->disableIRQ(XPOWERS_AXP2101_ALL_IRQ);
+        // Clear all interrupt flags
+        PMU->clearIrqStatus();
+        // Enable the required interrupt function
+        PMU->enableIRQ(
+            XPOWERS_AXP2101_BAT_INSERT_IRQ    | XPOWERS_AXP2101_BAT_REMOVE_IRQ      |   //BATTERY
+            XPOWERS_AXP2101_VBUS_INSERT_IRQ   | XPOWERS_AXP2101_VBUS_REMOVE_IRQ     |   //VBUS
+            XPOWERS_AXP2101_PKEY_SHORT_IRQ    | XPOWERS_AXP2101_PKEY_LONG_IRQ       |   //POWER KEY
+            XPOWERS_AXP2101_BAT_CHG_DONE_IRQ  | XPOWERS_AXP2101_BAT_CHG_START_IRQ       //CHARGE
+            // XPOWERS_AXP2101_PKEY_NEGATIVE_IRQ | XPOWERS_AXP2101_PKEY_POSITIVE_IRQ   |   //POWER KEY
+        );
+
+#endif
+    }
+
+    PMU->enableSystemVoltageMeasure();
+    PMU->enableVbusVoltageMeasure();
+    PMU->enableBattVoltageMeasure();
+    // It is necessary to disable the detection function of the TS pin on the board
+    // without the battery temperature detection function, otherwise it will cause abnormal charging
+    PMU->disableTSPinMeasure();
+
+    Serial.printf("=========================================\n");
+    if (PMU->isChannelAvailable(XPOWERS_DCDC1)) {
+        Serial.printf("DC1  : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_DCDC1)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_DCDC1));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_DCDC2)) {
+        Serial.printf("DC2  : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_DCDC2)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_DCDC2));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_DCDC3)) {
+        Serial.printf("DC3  : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_DCDC3)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_DCDC3));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_DCDC4)) {
+        Serial.printf("DC4  : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_DCDC4)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_DCDC4));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_DCDC5)) {
+        Serial.printf("DC5  : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_DCDC5)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_DCDC5));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_LDO2)) {
+        Serial.printf("LDO2 : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_LDO2)   ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_LDO2));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_LDO3)) {
+        Serial.printf("LDO3 : %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_LDO3)   ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_LDO3));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_ALDO1)) {
+        Serial.printf("ALDO1: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_ALDO1)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_ALDO1));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_ALDO2)) {
+        Serial.printf("ALDO2: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_ALDO2)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_ALDO2));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_ALDO3)) {
+        Serial.printf("ALDO3: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_ALDO3)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_ALDO3));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_ALDO4)) {
+        Serial.printf("ALDO4: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_ALDO4)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_ALDO4));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_BLDO1)) {
+        Serial.printf("BLDO1: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_BLDO1)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_BLDO1));
+    }
+    if (PMU->isChannelAvailable(XPOWERS_BLDO2)) {
+        Serial.printf("BLDO2: %s   Voltage: %04u mV \n",  PMU->isPowerChannelEnable(XPOWERS_BLDO2)  ? "+" : "-",  PMU->getPowerChannelVoltage(XPOWERS_BLDO2));
+    }
+    Serial.printf("=========================================\n");
+
+
+    // Set the time of pressing the button to turn off
+    PMU->setPowerKeyPressOffTime(XPOWERS_POWEROFF_4S);
+    uint8_t opt = PMU->getPowerKeyPressOffTime();
+    Serial.print("PowerKeyPressOffTime:");
+    switch (opt) {
+    case XPOWERS_POWEROFF_4S: Serial.println("4 Second");
+        break;
+    case XPOWERS_POWEROFF_6S: Serial.println("6 Second");
+        break;
+    case XPOWERS_POWEROFF_8S: Serial.println("8 Second");
+        break;
+    case XPOWERS_POWEROFF_10S: Serial.println("10 Second");
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}
+
+
+bool boardInit(InitType initType)
+{
+    // This function is used to perform board specific initializations.
+    // Required as part of standard template.
+
+    // InitType::Hardware        Must be called at start of setup() before anything else.
+    // InitType::PostInitSerial  Must be called after initSerial() before other initializations.    
+
+    bool success = true;
+    switch (initType)
+    {
+        case InitType::Hardware:
+            // Note: Serial port and display are not yet initialized and cannot be used use here.
+
+            // This board contains an AXP2101 power management chip.
+            // Power output must be enabled for several components before they can be initialized.
+            Wire.begin(SDA, SCL);
+
+            success = initPMU();
+
+            break;
+
+        case InitType::PostInitSerial:
+            // Note: If enabled Serial port and display are already initialized here.
+            // No actions required for this board.
+            break;      
+    }
+    return success;
+}
+
+
+#endif  // BSF_TTGO_T_BEAM_V1_2_H_


### PR DESCRIPTION
The T-BEAM-AXP2101 V1.2 has a new Chip for power control. It needs a different library (lewisxhe/XPowersLib). This pull request adds a new board definition to boards/ and platformio.ini